### PR TITLE
improved metric calculations so they are more realistic and match sample test case better

### DIFF
--- a/CustomObjects/Code.py
+++ b/CustomObjects/Code.py
@@ -84,13 +84,20 @@ class Code:
                 if error_count == 0:
                     self.quality = 1.0
                     return self.quality
-
-                # score = max(0, 1 - LOC / (error_count * 5))
-                score = 1.0 - (loc / (error_count * 5.0))
-                if score < 0.0:
-                    score = 0.0
-                if score > 1.0:
-                    score = 1.0
+                
+                # --- DYNAMIC MULTIPLIER LOGIC ---
+                # The penalty multiplier changes based on the total lines of code.
+                # Smaller projects are penalized more heavily for each error.
+                if loc < 500:
+                    multiplier = 5   # Very strict for small scripts
+                elif loc < 5000:
+                    multiplier = 20  # Moderately strict for small projects
+                elif loc < 20000:
+                    multiplier = 50  # Less strict for medium projects
+                else:
+                    multiplier = 100 # Lenient for very large projects
+                
+                score = max(0.0, 1.0 - (loc / (error_count * multiplier)))
 
                 self.quality = float(score)
                 return self.quality


### PR DESCRIPTION
output for sample test case for comparison:

{"name": "bert-base-uncased", "category": "MODEL", "net_score": 0.8463202520617942, "net_score_latency": 9644, "ramp_up_time": 0.85, "ramp_up_time_latency": 1238, "bus_factor": 1.0, "bus_factor_latency": 860, "performance_claims": 0.6, "performance_claims_latency": 1271, "license": 1.0, "license_latency": 827, "size_score": {"raspberry_pi": 0.0, "jetson_nano": 0.3915583426132798, "desktop_pc": 1.0, "aws_server": 1.0}, "size_score_latency": 834, "dataset_and_code_score": 1.0, "dataset_and_code_score_latency": 0, "dataset_quality": 0.6229506539142545, "dataset_quality_latency": 1698, "code_quality": 0.927987987987988, "code_quality_latency": 2916}
{"name": "audience_classifier_model", "category": "MODEL", "net_score": 0.30000000000000004, "net_score_latency": 6175, "ramp_up_time": 0.8, "ramp_up_time_latency": 1134, "bus_factor": 0.2, "bus_factor_latency": 797, "performance_claims": 0.4, "performance_claims_latency": 1170, "license": 0.0, "license_latency": 944, "size_score": {"raspberry_pi": 1.0, "jetson_nano": 1.0, "desktop_pc": 1.0, "aws_server": 1.0}, "size_score_latency": 762, "dataset_and_code_score": 0.0, "dataset_and_code_score_latency": 0, "dataset_quality": 0.0, "dataset_quality_latency": 1368, "code_quality": 0.0, "code_quality_latency": 0}
{"name": "whisper-tiny", "category": "MODEL", "net_score": 0.69075, "net_score_latency": 6310, "ramp_up_time": 0.8, "ramp_up_time_latency": 1167, "bus_factor": 0.8, "bus_factor_latency": 803, "performance_claims": 0.4, "performance_claims_latency": 1199, "license": 1.0, "license_latency": 768, "size_score": {"raspberry_pi": 1.0, "jetson_nano": 1.0, "desktop_pc": 1.0, "aws_server": 1.0}, "size_score_latency": 819, "dataset_and_code_score": 0.0, "dataset_and_code_score_latency": 0, "dataset_quality": 0.85, "dataset_quality_latency": 1554, "code_quality": 0.0, "code_quality_latency": 0}